### PR TITLE
Fix docker cluster naming

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: EasyCabinet
+name: easy-cabinet
 
 services:
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b72d0cd8-9c07-4e30-b655-b2b37fbab498)

Use the Docker Compose cluster naming rules, or strictly specify the version of docker compose that has syntax support